### PR TITLE
Add sample DKMS configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,4 +53,4 @@ wheel.
 
 + Change timer period:
 
-There have been reports that some games work better with a different timer period (see [#11](https://github.com/Kimplul/hid-tmff2/issues/11) and [#10](https://github.com/Kimplul/hid-tmff2/issues/10)). To change the timer period, add `options hid-tmt300rs timer_msecs=NUMBER` in `/etc/modprobe.d/hid-tmt300rs.conf`. The default timer period is 8, but numbers as low as 2 should work alright.
+There have been reports that some games work better with a different timer period (see [#11](https://github.com/Kimplul/hid-tmff2/issues/11) and [#10](https://github.com/Kimplul/hid-tmff2/issues/10)). To change the timer period, create `/etc/modprobe.d/hid-tmt300rs.conf` and add `options hid-tmt300rs timer_msecs=NUMBER` into it. The default timer period is 8, but numbers as low as 2 should work alright.

--- a/dkms.conf
+++ b/dkms.conf
@@ -1,0 +1,17 @@
+PACKAGE_NAME="hid-tmff2"
+PACKAGE_VERSION="0.0"
+AUTOINSTALL="yes"
+
+# By default, DKMS will add KERNELRELEASE to the make command line; however,
+# this will cause the kernel module build to infer that it was invoked via
+# Kbuild directly instead of DKMS. The dkms(8) manual page recommends quoting
+# the 'make' command name to suppress this behavior.
+MAKE[0]="'make'"
+
+# The list of kernel modules.
+#__DKMS_MODULES
+BUILT_MODULE_NAME[0]="hid-tminit"
+BUILT_MODULE_LOCATION="hid-tminit/"
+DEST_MODULE_LOCATION[0]="/kernel/drivers/hid"
+BUILT_MODULE_NAME[1]="hid-tmt300rs"
+DEST_MODULE_LOCATION[1]="/kernel/drivers/hid"


### PR DESCRIPTION
The source directory name has to include the version and match the one
in dkms.conf, e.g. /usr/src/hid-tmff2-0.0 & PACKAGE_VERSION="0.0".

To add: dkms add -m hid-tmff2 -v 0.0
To remove: dkms remove hid-tmff2/0.0 --all
To build: systemctl restart dkms.service

I went for version 0.0 for now as the driver doesn't have any release/version yet.
For https://github.com/cazzoo/hid-tmff2 it can be extended by adding:
```
BUILT_MODULE_NAME[2]="hid-tmt500rs"
DEST_MODULE_LOCATION[2]="/kernel/drivers/hid"
```