### PR TITLE
Force effect corrections part1

### DIFF
--- a/src/tmt300rs/hid-tmt300rs.c
+++ b/src/tmt300rs/hid-tmt300rs.c
@@ -347,6 +347,7 @@ static u8 damper_values[] = {
 static void t300rs_calculate_periodic_values(struct ff_effect *effect)
 {
 	struct ff_periodic_effect *periodic = &effect->u.periodic;
+	int16_t headroom;
 
 	effect->replay.length -= 1;
 
@@ -362,6 +363,11 @@ static void t300rs_calculate_periodic_values(struct ff_effect *effect)
 
 	/* the interval [0; 32677[ is used by the wheel for the [0; 360[ degree phase shift */
 	periodic->phase = periodic->phase * 32677 / 0x10000;
+
+	headroom = 0x7FFF - periodic->magnitude;
+	/* magnitude + offset cannot be outside the valid magnitude range, */
+	/* otherwise the wheel behaves incorrectly */
+	periodic->offset = clamp(periodic->offset, -headroom, headroom);
 }
 
 int t300rs_send_buf(struct t300rs_device_entry *t300rs, u8 *send_buffer, size_t len)

--- a/src/tmt300rs/hid-tmt300rs.c
+++ b/src/tmt300rs/hid-tmt300rs.c
@@ -630,6 +630,8 @@ static int t300rs_update_constant(struct t300rs_device_entry *t300rs,
 	int16_t level;
 
 	level = (constant.level * fixp_sin16(effect.direction * 360 / 0x10000)) / 0x7fff;
+	/* the Windows driver uses the range [-16385;16381] */
+	level = level / 2;
 
 	if ((constant.level != constant_old.level) || (effect.direction != old.direction)) {
 
@@ -948,6 +950,8 @@ static int t300rs_upload_constant(struct t300rs_device_entry *t300rs,
 	int ret;
 
 	level = (constant.level * fixp_sin16(effect.direction * 360 / 0x10000)) / 0x7fff;
+	/* the Windows driver uses the range [-16385;16381] */
+	level = level / 2;
 	duration = effect.replay.length - 1;
 
 	offset = effect.replay.delay;


### PR DESCRIPTION
I read #46 and wondered why they can feel it different with the driver installed inside the prefix, I thought maybe the driver applies some modification to the values that got sent out.

To test the things out I installed a Win10 in VirtualBox, installed the TM drivers, and wrote a POC program to send constant force effect with a range of force levels. I have done the same on Linux and Wine and compared the force levels that got sent out using Wireshark.

Some notable differences between the two:

- On Windows, the available range is from `-10000` to `10000` (`DI_FFNOMINALMAX`)
- On Linux, the range is from`-0x8000` to `0x7FFF`

Things I did:
- Wrote a POC for Windows using dinput to send a constant force effect with only the `lMagnitude` (level) set
- Wrote a POC for Linux to send a constant force effect with only the `level` set
- Used the same Windows program under Wine
- I tried to send new effect uploads instead of updates (Wine doesn't like my idea)

Things I found:

- Windows driver maps the `[-10000;10000]` range to `[-16385;16381]`
- Windows driver handles `<-10000` and `>10000` values, and the sent force is `-16385` and `16381` respectively
- Wine doesn't like `<-10000` and `>10000` values, so I left them out
- Wine really likes to send updates (even for unchanged parameters) instead of new effect uploads
- This driver maps the `[-0x8000;0x7FFF]` range to `[-0x8000;0x7FFF]`, so essentially from 50% in either direction the force is unchanged (I don't feel any difference in the force above `16381`)
- The TM drivers are not installing correctly under Wine, so made no difference for me. Maybe the Thrustmaster SDK (`tm_api_lib_*.dll`)  is involved when a difference is made.

Based on these observations I gathered the requested and sent out values under Windows, Wine, and Linux and made a nice plot out of it. I also modified the driver to roughly match the force levels of the Windows driver by dividing the force level by 2.

Plot of the original and the modified force levels:
![ffbplot](https://github.com/Kimplul/hid-tmff2/assets/36025825/45ad0e89-d8e5-4732-b9d2-c087af5ea261)

All the things I said are relevant only to the T300RS, I have no other wheels available.

Checklist:

- [x] Constant force
- [ ] Periodic
- [ ] Square wave
- [ ] Triangle wave
- [ ] Sine wave
- [ ] Saw up wave
- [ ] Saw down wave
- [ ] Ramp
- [ ] Spring
- [ ] Friction
- [ ] Damper
- [ ] Rumble
- [ ] Inertia
- [ ] Gain
- [ ] Autocenter
- [ ] Envelope(s)


If you think it's not a complete nonsense, and it's wroth to go through the checklist, let me know.

POCs
[ffbtest_win.cpp.txt](https://github.com/user-attachments/files/15857657/ffbtest_win.cpp.txt)
[ffbtest_linux.cpp.txt](https://github.com/user-attachments/files/15857660/ffbtest_linux.cpp.txt)


Wireshark captures
[const_-8000-7fff_win.pcapng.gz](https://github.com/user-attachments/files/15857448/const_-8000-7fff_win.pcapng.gz)
[const_-8000-7fff_linux_wheel.pcapng.gz](https://github.com/user-attachments/files/15857449/const_-8000-7fff_linux_wheel.pcapng.gz)
[const_-10000-10000_wine_wheel.pcapng.gz](https://github.com/user-attachments/files/15857450/const_-10000-10000_wine_wheel.pcapng.gz)
[const_-8000-7fff_linux_corr2_wheel.pcapng.gz](https://github.com/user-attachments/files/15857452/const_-8000-7fff_linux_corr2_wheel.pcapng.gz)
[const_-10000-10000_wine_corr2_wheel.pcapng.gz](https://github.com/user-attachments/files/15857453/const_-10000-10000_wine_corr2_wheel.pcapng.gz)

Gathered data
[ffb.ods](https://github.com/user-attachments/files/15857455/ffb.ods)
