### PR TITLE
Effect corrections part3

### DIFF
--- a/docs/FFBEFFECTS.md
+++ b/docs/FFBEFFECTS.md
@@ -43,7 +43,7 @@ have model specific peculiarities, though.
 
 ### Stopping/removing (why are they rolled into one?)
 ```
-    60 00 - standard header 
+    60 00 - standard header
     01 - ID
     89 - playing options
     00 - stop
@@ -99,7 +99,7 @@ have model specific peculiarities, though.
 ```
 
 ## FF_AUTOCENTER:
-```    
+```
     60 08 - header plus settings?
     03 - set autocenter force
     8f 02 - force (between ff ff and 00 00)
@@ -110,7 +110,7 @@ have model specific peculiarities, though.
 ```
 
 ## FF_GAIN:
-```    
+```
     60 02 - header plus gain?
     bf - gain (between ff and 00)
     00 00 00 00 00 00 00 00 00 00 00 00 00
@@ -130,7 +130,8 @@ have model specific peculiarities, though.
     00 00 - attack_level ***
     00 00 - fade_length
     00 00 - fade_level ***
-    00 4f - ?
+    00 - effect type?
+    4f
     f7 17 - time in milliseconds, unsigned
     00 00
     07 00 - offset from start(?)
@@ -200,15 +201,6 @@ envelope (all):
 ```
 
 #### Duration:
-Update type:
-
-```
- binary   hex
-01000001  41  duration
-01000100  44  offset
-01000101  45  duration + offset
-```
-
 ```
     60 00 - standard header
     01 - ID
@@ -274,8 +266,6 @@ magnitude + envelope + duration + offset:
 ```
 
 ## FF_RAMP
-
-Ramps seem to follow triangle wave parameters.
 
 ```
 00001110 00000001 0e 01 - slope
@@ -361,7 +351,7 @@ Valid:
 ### Modifying:
 
 ```
-center: 
+center:
     60 00 - standard header
     01 - ID
     0e 02
@@ -408,7 +398,7 @@ duration:
     4e 08
     88 13 - duration
     04 - effect type? must reflect the actual inversion 04 or 05
-    41 - update type
+    41 - update type, see Update type section
     88 13 - duration
     00 00 00 00 00
     00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
@@ -420,7 +410,7 @@ offset:
     01 - ID
     49
     04 - effect type? must reflect the actual inversion 04 or 05
-    44 - update type
+    44 - update type, see Update type section
     00 00 - offset
     00 00 00 00 00 00 00 00
     00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
@@ -433,7 +423,7 @@ duration + offset:
     4e 08
     88 13 - duration
     04 - effect type? must reflect the actual inversion 04 or 05
-    45 - update type
+    45 - update type, see Update type section
     88 13 - duration
     00 00 - offset
     00 00 00
@@ -446,7 +436,7 @@ dir + offset:
     01 - ID
     49
     05 - effect type? must reflect the actual inversion 04 or 05
-    44 - update type
+    44 - update type, see Update type section
     00 00 - offset
     00 00 00 00 00 00 00 00
     00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
@@ -545,7 +535,7 @@ duration + offset + envelope + slope + center + invert:
     dc 05 - fade length
     32 1a - fade level
     04 - effect type? (invert) 04 or 05
-    45 - update type
+    45 - update type, see Update type section
     88 13 - length 2
     00 00 - offset
     00 00 00 00 00 00 00
@@ -595,7 +585,7 @@ duration + offset + envelope + slope + center + invert:
 4th byte 5th byte   hex
 00001110 01000001  0e 41  positive coefficient
 00001110 01000010  0e 42  negative coefficient
-00001110 01000011  0e 43  both     coefficint
+00001110 01000011  0e 43  both     coefficient
 00001110 01001100  0e 4c  right and left deadband
 00001110 01010000  0e 50  positive saturation
 00001110 01100000  0e 60  negative saturation
@@ -638,7 +628,7 @@ The order of the fields are defined in the `all effect specific parameters + dur
     positive and negative coefficient:
     60 00
     01 - ID
-    0e 43 
+    0e 43
     ab 67 - right coefficient, signed, between 01 80 (-32767) and fc 7f (32764)
     50 18 - left coefficient, signed, between 01 80 (-32767) and fc 7f (32764)
     00 00 00 00 00 00 00
@@ -715,7 +705,7 @@ The order of the fields are defined in the `all effect specific parameters + dur
     fd 5f - positive saturation
     fd 5f - negative saturation
     06 - effect type (condition)?
-    45 - update type, see below
+    45 - update type, see Update type section
     10 27 - length in milliseconds
     00 00 - offset in milliseconds
     00 00 00 00 00 00 00 00 00 00
@@ -725,22 +715,12 @@ The order of the fields are defined in the `all effect specific parameters + dur
 ```
 
 ### Duration:
-
-Update type:
-
-```
-6th byte  hex
-01000001  41  length
-01000100  44  offset
-01000101  45  length + offset
-```
-
 ```
     60 00 - standard header
     01 - ID
     49
     06 - effect type (condition)?
-    45 - update type
+    45 - update type, see Update type section
     6c 20 - length in milliseconds
     00 00 - offset in milliseconds
     00 00 00 00 00 00
@@ -866,9 +846,7 @@ envelope (all):
                      03 - Sine
                      04 - Sawtooth up
                      05 - Sawtooth down
-    45 - update type 41 - duration
-                     44 - offset
-                     45 - duration + offset
+    45 - update type, see Update type section
     74 27 - duration
     00 00 - offset
     00 00 00 00 00 00
@@ -928,9 +906,7 @@ magnitude + offset + phase + period + envelope + duration + offset:
                      03 - Sine
                      04 - Sawtooth up
                      05 - Sawtooth down
-    45 - update type 41 - duration
-                     44 - offset
-                     45 - duration + offset
+    45 - update type, see Update type section
     74 27 - duration
     00 00 - offset
     00 00 00 00 00
@@ -983,6 +959,15 @@ Uses the same calculation as attack length.
 
 between 0 and 32764
 
+
+## Update type
+
+```
+binary    hex
+01000001  41  duration
+01000100  44  offset
+01000101  45  duration + offset
+```
 
 ## PS4 Input `rdesc`
 ```

--- a/docs/FFBEFFECTS.md
+++ b/docs/FFBEFFECTS.md
@@ -662,11 +662,10 @@ Update type:
     00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
 ```
 
-### Offset: `N/A` 
-
 ## FF_PERIODIC:
+
 ### Init
-```   
+```
     60 00 - standard header
     01 - ID
     6b - new periodic effect
@@ -675,7 +674,7 @@ Update type:
     00 00 - phase (left/right) between 00 00 and 4a f7 (32586)
             meaning is 0 to ~359 deg phase shift in 5b steps
     e8 03 - period between 00 00 and ff ff (in milliseconds)
-    00 80 
+    00 80
     00 00 - attack_length
     00 00 - attack_level ***
     00 00 - fade_length
@@ -695,8 +694,27 @@ Update type:
 ```
 
 ### Modifying:
+
 ```
-    magnitude:
+4th byte 5th byte  hex
+00001110 00000001 0e 01 - magnitude
+00001110 00000010 0e 02 - offset
+00001110 00000100 0e 04 - phase
+00001110 00001000 0e 08 - period
+00001110 00001111 0e 0f - magnitude + offset + phase + period
+01001001          49    - duration / offset / duration + offset
+00110001 10000001 31 81 - envelope attack length
+00110001 10000010 31 82 - envelope attack level
+00110001 10000100 31 84 - envelope fade length
+00110001 10001000 31 88 - envelope fade level
+00101001          29    - envelope (all)
+00101110 00001111 2e 0f - magnitude + offset + phase + period + envelope
+00110110 00001111 36 0f - magnitude + offset + phase + period + envelope attack length & level
+01101110 00001111 6e 0f - magnitude + offset + phase + period + envelope + duration + offset
+```
+
+```
+magnitude:
     60 00
     02 - ID
     0e 01
@@ -706,118 +724,132 @@ Update type:
     00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
     00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
 
-    offset of effect:
+magnitude + offset + phase + period:
     60 00
-    02 - ID
-    0e 02
-    64 35 - value, between ff bf (-16385) and fd 3f (16381)
-    00 00 00 00 00 00 00 00 00
-    00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
-    00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
-    00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
-
-    phase:
-    60 00
-    02 - ID
-    0e 04
-    64 35 - value, between 00 00 and 4a f7 (32586) in 5b steps
+    01 - ID
+    0e 0f
+    dd 3f - magnitude, between 00 00 and fc 7f (32764)
+    cb 0c - offset, between ff bf (-16385) and fd 3f (16381)
+    5a 00 - phase, between 00 00 and 4a f7 (32586) in 5b steps
             meaning is 0 to 359 deg phase shift
-    00 00 00 00 00 00 00 00 00
-    00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
-    00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
-    00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
-
-    period:
-    60 00
-    02 - ID
-    0e 08
-    64 35 - value, between 00 00 and ff ff (in milliseconds)
-    00 00 00 00 00 00 00 00 00
+    f8 2a - period, between 00 00 and ff ff (in milliseconds)
+    00 00 00
     00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
     00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
     00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
 
 ```
 
-### Envelope:
+#### Envelope:
 ```
+envelope attack/fade level/length:
+    multiple values can be updated with one packet
+
     60 00 - standard header
     01 - ID
-    31 - modify envelope
-    84 - ID of envelope attribute ( attack_level 82,
-                                    attack_length 81,
-                                    fade_level 88,
-                                    fade_length 84  )
-    63 04 - value attribute should be set to
-    00 00 00 00 00 00 00 00 00
+    31 85
+    d0 07 - attack length
+    dc 05 - fade length
+    00 00 00 00 00 00 00
+    00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+    00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+    00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+
+envelope (all):
+    60 00 - standard header
+    01 - ID
+    29
+    d0 07 - attack length
+    69 34 - attack level
+    dc 05 - fade length
+    32 1a - fade level
+    00 00 00 00
     00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
     00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
     00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
 ```
 
-### Duration:
+#### Duration:
 ```
-    Square:
     60 00
     01 - ID
-    49 - ?
-    01 - Effect type
-    41 - ?
-    4e 0c - Time in milliseconds
-    00 00 00 00 00 00 00 00
-    00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
-    00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
-    00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
-
-    Sine:
-    60 00
-    01 - ID
-    49 - ?
-    03 - Effect type
-    41 - ?
-    ec 13 - Time in milliseconds
-    00 00 00 00 00 00 00 00
-    00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
-    00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
-    00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
-
-    Triangle:
-    60 00
-    01 - ID
-    49 - ?
-    02 - Effect type
-    41 - ?
-    4e 0c - Time in milliseconds
-    00 00 00 00 00 00 00 00
-    00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
-    00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
-    00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
-
-    Sawtooth up:
-    60 00
-    01 - ID
-    49 - ?
-    04 - Effect type
-    41 - ?
-    4e 0c - Time in milliseconds
-    00 00 00 00 00 00 00 00
-    00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
-    00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
-    00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
-
-    Sawtooth down:
-    60 00
-    01 - ID
-    49 - ?
-    05 - Effect type
-    41 - ?
-    ec 13 - Time in milliseconds
-    00 00 00 00 00 00 00 00
+    49
+    03 - effect type 01 - Square
+                     02 - Triangle
+                     03 - Sine
+                     04 - Sawtooth up
+                     05 - Sawtooth down
+    45 - update type 41 - duration
+                     44 - offset
+                     45 - duration + offset
+    74 27 - duration
+    00 00 - offset
+    00 00 00 00 00 00
     00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
     00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
     00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
 ```
-### Offset: `N/A ?`
+
+#### Combined
+
+```
+magnitude + offset + phase + period + envelope:
+    60 00
+    01 - ID
+    2e 0f
+    dd 3f - magnitude, between 00 00 and fc 7f (32764)
+    cb 0c - offset
+    5a 00 - phase
+    f8 2a - period
+    dc 05 - attack length
+    30 73 - attack level
+    e8 03 - fade length
+    30 73 - fade level
+    00 00 00 00 00 00 00 00 00 00 00
+    00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+    00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+
+magnitude + offset + phase + period + envelope attack length & level:
+    60 00
+    01 - ID
+    36 0f
+    dd 3f - magnitude
+    cb 0c - offset
+    5a 00 - phase
+    f8 2a - period
+    83 - envelope update type
+    e8 03 - attack length
+    cc 0c - attack level
+    00 00 00 00 00 00 00 00 00 00 00 00 00 00
+    00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+    00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+
+magnitude + offset + phase + period + envelope + duration + offset:
+    60 00
+    01 - ID
+    6e 0f
+    dd 3f - magnitude
+    cb 0c - offset
+    5a 00 - phase
+    f8 2a - period
+    cc 0c - attack length
+    e8 03 - attack level
+    dc 05 - fade length
+    cc 0c - fade level
+    03 - effect type 01 - Square
+                     02 - Triangle
+                     03 - Sine
+                     04 - Sawtooth up
+                     05 - Sawtooth down
+    45 - update type 41 - duration
+                     44 - offset
+                     45 - duration + offset
+    74 27 - duration
+    00 00 - offset
+    00 00 00 00 00
+    00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+    00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+```
 
 ## PS4 Input `rdesc`
 ```

--- a/docs/FFBEFFECTS.md
+++ b/docs/FFBEFFECTS.md
@@ -142,7 +142,21 @@ have model specific peculiarities, though.
 
 ### Modifying (For dynamic updating of effects)
 
-#### Direction: ``N/A``
+```
+4th byte 5th byte  hex
+00001010          0a    - magnitude
+01001001          49    - duration / offset / duration + offset
+00110001 10000001 31 81 - envelope attack length
+00110001 10000010 31 82 - envelope attack level
+00110001 10000100 31 84 - envelope fade length
+00110001 10001000 31 88 - envelope fade level
+00101001          29    - envelope (all)
+00101010          2a    - magnitude + envelope
+01101010          6a    - magnitude + envelope + offset
+00110010          32    - magnitude + envelope attack length & level
+01110010          72    - magnitude + envelope attack length & level + duration
+01101010          6a    - magnitude + envelope + duration + offset
+```
 
 #### Constant force:
 ```
@@ -158,33 +172,106 @@ have model specific peculiarities, though.
 
 #### Envelope:
 ```
+envelope attack/fade level/length:
+    multiple values can be updated with one packet
+
     60 00 - standard header
     01 - ID
-    31 - modify envelope
-    84 - ID of envelope attribute ( attack_level 82,
-                                    attack_length 81,
-                                    fade_level 88,
-                                    fade_length 84 )
-    63 04 - value attribute should be set to ?***?
-    00 00 00 00 00 00 00 00 00
+    31 85
+    e8 03 - attack length
+    dc 05 - fade length
+    00 00 00 00 00 00 00
+    00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+    00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+    00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+
+envelope (all):
+    60 00 - standard header
+    01 - ID
+    29
+    e8 03 - attack length
+    cc 0c - attack level
+    dc 05 - fade length
+    cc 0c - fade level
+    00 00 00 00
     00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
     00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
     00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
 ```
 
 #### Duration:
+Update type:
+
+```
+ binary   hex
+01000001  41  duration
+01000100  44  offset
+01000101  45  duration + offset
+```
+
 ```
     60 00 - standard header
     01 - ID
-    49 00 41 - modify timing?
-    6c 20 - length in milliseconds
-    00 00 00 00 00 00 00 00
+    49
+    00 - effect type?
+    45 - update type
+    88 13 - duration in milliseconds
+    00 00 - offset in milliseconds
+    00 00 00 00 00 00
     00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
     00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
     00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
 ```
 
-#### Offset: `N/A` 
+#### Combined:
+```
+magnitude + envelope:
+    60 00 - standard header
+    01 - ID
+    2a
+    fd 3f - magnitude
+    e8 03 - attack length
+    cc 0c - attack level
+    dc 05 - fade length
+    cc 0c - fade level
+    00 00
+    00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+    00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+    00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+
+magnitude + envelope attack length & level + duration:
+    60 00 - standard header
+    01 - ID
+    72
+    fd 3f - magnitude
+    83 - envelope update type
+    e8 03 - attack length
+    cc 0c - attack level
+    00 - effect type?
+    41 - update type
+    88 13 - duration
+    00
+    00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+    00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+    00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+
+magnitude + envelope + duration + offset:
+    60 00 - standard header
+    01 - ID
+    6a
+    fd 3f - magnitude
+    e8 03 - attack length
+    cc 0c - attack level
+    dc 05 - fade length
+    cc 0c - fade level
+    00 - effect type?
+    45 - update type
+    88 13 - duration
+    00 00 - offset
+    00 00 00 00 00 00 00 00 00 00 00 00
+    00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+    00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+```
 
 ## FF_RAMP
 

--- a/docs/FFBEFFECTS.md
+++ b/docs/FFBEFFECTS.md
@@ -938,6 +938,52 @@ magnitude + offset + phase + period + envelope + duration + offset:
     00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
 ```
 
+## Envelope
+
+Envelope related parameters are the same across all the effects. The only
+difference is which effect specific parameters are used during the calculations.
+
+Damper, Friction, Inertia, and Spring do not support envelope.
+
+### attack length
+
+between 0 and 65535
+
+On Windows, it has a minimum value depending on how far is the target from the
+attack/fade level. This means that in case of an envelope that goes from zero
+to max has the minimum length of 256ms.
+
+```length = abs((effectval * 32768 / effectmax - level) / 128)```
+
+`effectval` is the current value of an effect specific parameter
+
+`effectmax` is the maximum value of `effectval`
+
+`level` is the current value of the attack/fade level
+
+Used parameters for each effect:
+
+| Effect   | Parameter |
+|----------|-----------|
+| Constant | Strength  |
+| Periodic | Magnitude |
+| Ramp     | Slope     |
+
+### attack level
+
+between 0 and 32764
+
+### fade length
+
+between 0 and 65535
+
+Uses the same calculation as attack length.
+
+### fade level
+
+between 0 and 32764
+
+
 ## PS4 Input `rdesc`
 ```
     ff00.0021 = 0

--- a/src/tmt300rs/hid-tmt300rs.c
+++ b/src/tmt300rs/hid-tmt300rs.c
@@ -597,8 +597,8 @@ static int t300rs_update_constant(struct t300rs_device_entry *t300rs,
 
 		packet_mod_constant->effect_type = 0x00;
 		packet_mod_constant->update_type = 0x45;
-		packet_mod_constant->duration = length;
-		packet_mod_constant->offset = effect.replay.delay;
+		packet_mod_constant->duration = cpu_to_le16(length);
+		packet_mod_constant->offset = cpu_to_le16(effect.replay.delay);
 
 		ret = t300rs_send_int(t300rs);
 		if (ret)
@@ -797,8 +797,8 @@ static int t300rs_update_periodic(struct t300rs_device_entry *t300rs,
 
 		packet_mod_periodic->effect_type = periodic.waveform - 0x57;
 		packet_mod_periodic->update_type = 0x45;
-		packet_mod_periodic->duration = length;
-		packet_mod_periodic->play_offset = effect.replay.delay;
+		packet_mod_periodic->duration = cpu_to_le16(length);
+		packet_mod_periodic->play_offset = cpu_to_le16(effect.replay.delay);
 
 		ret = t300rs_send_int(t300rs);
 		if (ret)

--- a/src/tmt300rs/hid-tmt300rs.c
+++ b/src/tmt300rs/hid-tmt300rs.c
@@ -379,7 +379,7 @@ static uint16_t t300rs_condition_max_saturation(uint16_t effect_type)
 	return 0x7ffc;
 }
 
-static uint16_t t300rs_condition_effect_type(uint16_t effect_type)
+static uint8_t t300rs_condition_effect_type(uint16_t effect_type)
 {
 	if(effect_type == FF_SPRING)
 		return 0x06;


### PR DESCRIPTION
Part1: #105
Part2: #107

Planned changes:

 - [x] Ramp
 - [x] Envelope
 - [x] Revise constant and periodic effects

### Ramp

It seems the Windows driver has a bug that is affecting the ramp effect. Changing the invert parameter without changing the duration or the delay causes the effect to stop. I detailed the issue in the docs and found a solution to it.

There is a Wine issue too, the `slope` and `center` or with the old terminology the `difference` and `level` is always `0`, so the `start_level` and the `end_level` must be `0` too. Happening with and without this PR. I'm using wine 9.13 right now (arch package).
Can someone confirm that this happening to them too?
Still not working as of 9.15.

### Envelope

On Windows, the attack/fade_length has a minimum value depending on how far is the target from the attack/fade level. This means that in case of an envelope that goes from zero to max has the minimum length of 256ms.

There is a function that I figured out (in the docs), but choose to not implement it because I see no reason to do it currently. Tested with a constant effect using a 0% to 100% envelope. On Windows the minimum length is 256ms (enforced by the driver) however I tested it on Linux with values of 256, 128, 64, 0 and all of them can be distinguishable just by the feeling of the wheel therefore the wheel handles them.


Spreadsheet: [ffb_p3.zip](https://github.com/user-attachments/files/16731749/ffb_p3.zip) (only the relevant sheets, grown too large)
Windows test program: [ffbtest_win.cpp.txt](https://github.com/user-attachments/files/16731756/ffbtest_win.cpp.txt)
Linux test program: [ffbtest_linux.cpp.txt](https://github.com/user-attachments/files/16731760/ffbtest_linux.cpp.txt)

---

There are still some missing pieces like the trigger buttons and the meaning of some bits. The following are mainly notes for someone who wants to continue the process (maybe future me).

There is an update message for every effect with the header of `49`. The same fields can be found in every init packet (without the header) titled as "effect type" and "update type". During init the update type has the value of `4f` and I suspect there are 2 more fields in there because during update only `41` (duration) and `44` (offset) are observed. Maybe the trigger buttons are hidden in there.

The effect can be started immediately by setting the MSB bit of the `new * effect` field of an init packet. `ea` instead of `6a` in case of constant effect. Using that, at the end of the packet 2 new bytes are appearing in connection with the iteration count of the `IDirectInputEffect::Start` method.

Windows driver can merge multiple updates into one if they were sent close to each other.