### PR TITLE
DKMS module fails to install due to wrong module name

### DIFF
--- a/dkms/dkms.conf
+++ b/dkms/dkms.conf
@@ -11,7 +11,7 @@ CLEAN[0]="'make' KDIR=\"$kernel_source_dir\" clean"
 
 # The list of kernel modules.
 #__DKMS_MODULES
-BUILT_MODULE_NAME[0]="hid-tminit"
+BUILT_MODULE_NAME[0]="hid-tminit-new"
 BUILT_MODULE_LOCATION="deps/hid-tminit/"
 DEST_MODULE_LOCATION[0]="/kernel/drivers/hid"
 BUILT_MODULE_NAME[1]="hid-tmff-new"


### PR DESCRIPTION
Today I've tried to install the DKMS module and had some issues, but I managed to fix it.

The `deps/hid-tminit/Kbuild` generates `hid-tminit-new.ko` file, but current `dkms.conf` makes DKMS look for file `hid-tminit.ko`, so the installation fails.