### PR TITLE
Update README to mention linuxconsole tools dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,13 @@ sudo pacman -S linux-neptune-68-headers
 
 If none of the above work, please do open up an issue.
 
+Joystick utilities from [linuxconsole tools](http://sf.net/projects/linuxconsole/) are needed for uvdev rules to work:
+```shell
+sudo apt install joystick          # Debian-based
+sudo pacman -S joyutils            # Arch-based
+sudo yum install linuxconsoletools # Fedora-based
+```
+
 #### Manual installation
 + Unplug wheel from computer
 + Run


### PR DESCRIPTION
I had a huge dead zone on Euro Truck Simulator 2 although I've installed uvdev rules.
I didn't know I had to install some utilities to make uvdev rules work.

Here's each distro's package repository:
DEB: https://packages.debian.org/bookworm/joystick
AUR: https://archlinux.org/packages/extra/x86_64/joyutils/
RPM: https://src.fedoraproject.org/rpms/linuxconsoletools

I use Ubuntu so I only can confirm `apt` command works.