### PR TITLE
fix force feedback arithmetic and wheel input filtering

### DIFF
--- a/src/hid-tmff2.c
+++ b/src/hid-tmff2.c
@@ -48,6 +48,11 @@ module_param(gain, ushort, 0);
 MODULE_PARM_DESC(gain,
 		"Level of gain (0-65535)");
 
+static u16 tmff2_scale_gain(u16 value)
+{
+	return (u32)value * gain / GAIN_MAX;
+}
+
 static spinlock_t lock;
 
 static struct tmff2_device_entry *tmff2_from_hdev(struct hid_device *hdev)
@@ -244,7 +249,7 @@ static ssize_t gain_store(struct device *dev,
 
 	gain = value;
 	if (tmff2->set_gain) /* if we can, update gain immediately */
-		tmff2->set_gain(tmff2->data, (GAIN_MAX * gain) / GAIN_MAX);
+		tmff2->set_gain(tmff2->data, gain);
 
 	return count;
 }
@@ -268,7 +273,7 @@ static void tmff2_set_gain(struct input_dev *dev, uint16_t value)
 		return;
 	}
 
-	if (tmff2->set_gain(tmff2->data, (value * gain) / GAIN_MAX))
+	if (tmff2->set_gain(tmff2->data, tmff2_scale_gain(value)))
 		hid_warn(tmff2->hdev, "unable to set gain\n");
 }
 
@@ -644,7 +649,7 @@ static int tmff2_wheel_init(struct tmff2_device_entry *tmff2)
 	/* set defaults wherever possible */
 	if (tmff2->set_gain) {
 		ff->set_gain = tmff2_set_gain;
-		tmff2->set_gain(tmff2->data, (GAIN_MAX * gain) / GAIN_MAX);
+		tmff2->set_gain(tmff2->data, gain);
 	}
 
 	if (tmff2->set_autocenter)

--- a/src/hid-tmff2.c
+++ b/src/hid-tmff2.c
@@ -807,6 +807,26 @@ static void tmff2_remove(struct hid_device *hdev)
 	kfree(tmff2);
 }
 
+static int tmff2_input_configured(struct hid_device *hdev,
+				  struct hid_input *hidinput)
+{
+	struct input_dev *input = hidinput->input;
+	int axis;
+
+	if (!input->absinfo)
+		return 0;
+
+	for (axis = ABS_X; axis <= ABS_BRAKE; axis++) {
+		if (!test_bit(axis, input->absbit))
+			continue;
+
+		input_abs_set_fuzz(input, axis, 0);
+		input_abs_set_flat(input, axis, 0);
+	}
+
+	return 0;
+}
+
 static const struct hid_device_id tmff2_devices[] = {
 	/* t300rs and variations */
 	{HID_USB_DEVICE(USB_VENDOR_ID_THRUSTMASTER, TMT300RS_PS3_NORM_ID)},
@@ -831,6 +851,7 @@ static struct hid_driver tmff2_driver = {
 	.probe = tmff2_probe,
 	.remove = tmff2_remove,
 	.report_fixup = tmff2_report_fixup,
+	.input_configured = tmff2_input_configured,
 };
 module_hid_driver(tmff2_driver);
 

--- a/src/hid-tmff2.c
+++ b/src/hid-tmff2.c
@@ -43,8 +43,8 @@ MODULE_PARM_DESC(alt_mode,
 		"Alternate mode, eg. F1 mode");
 
 #define GAIN_MAX 65535
-int gain = 40000;
-module_param(gain, int, 0);
+u16 gain = 40000;
+module_param(gain, ushort, 0);
 MODULE_PARM_DESC(gain,
 		"Level of gain (0-65535)");
 
@@ -230,14 +230,15 @@ static ssize_t gain_store(struct device *dev,
 		struct device_attribute *attr, const char *buf, size_t count)
 {
 	struct tmff2_device_entry *tmff2 = tmff2_from_hdev(to_hid_device(dev));
-	unsigned int value;
+	u16 value;
 	int ret;
 
 	if (!tmff2)
 		return -ENODEV;
 
-	if ((ret = kstrtouint(buf, 0, &value))) {
-		dev_err(dev, "kstrtouint failed at gain_store: %i", ret);
+	ret = kstrtou16(buf, 0, &value);
+	if (ret) {
+		dev_err(dev, "failed to parse gain: %d\n", ret);
 		return ret;
 	}
 
@@ -251,7 +252,7 @@ static ssize_t gain_store(struct device *dev,
 static ssize_t gain_show(struct device *dev,
 		struct device_attribute *attr, char *buf)
 {
-	return scnprintf(buf, PAGE_SIZE, "%i\n", gain);
+	return scnprintf(buf, PAGE_SIZE, "%u\n", gain);
 }
 static DEVICE_ATTR_RW(gain);
 

--- a/src/hid-tmff2.h
+++ b/src/hid-tmff2.h
@@ -11,7 +11,7 @@ extern int spring_level;
 extern int damper_level;
 extern int friction_level;
 extern int range;
-extern int gain;
+extern u16 gain;
 extern int alt_mode;
 
 #define USB_VENDOR_ID_THRUSTMASTER 0x044f

--- a/src/tmt300rs/hid-tmt300rs.c
+++ b/src/tmt300rs/hid-tmt300rs.c
@@ -344,30 +344,35 @@ static uint16_t t300rs_calculate_length(uint16_t length)
 	return length;
 }
 
+static s32 t300rs_scale_direction(s16 level, u16 direction)
+{
+	return (s32)level * fixp_sin16(direction * 360 / 0x10000) / 0x7fff;
+}
+
 static int16_t t300rs_calculate_constant_level(int16_t level, uint16_t direction)
 {
-	level = (level * fixp_sin16(direction * 360 / 0x10000)) / 0x7fff;
+	s32 scaled_level = t300rs_scale_direction(level, direction);
 
 	/* the Windows driver uses the range [-16385;16381] */
-	level = level / 2;
-
-	return level;
+	return scaled_level / 2;
 }
 
 static void t300rs_calculate_periodic_values(struct ff_effect *effect)
 {
 	struct ff_periodic_effect *periodic = &effect->u.periodic;
-	int16_t headroom;
+	s32 magnitude, headroom;
 
-	periodic->magnitude = (periodic->magnitude * fixp_sin16(effect->direction * 360 / 0x10000)) / 0x7fff;
+	magnitude = t300rs_scale_direction(periodic->magnitude,
+					   effect->direction);
 
-	if (periodic->magnitude < 0){
+	if (magnitude < 0) {
 		/* the wheel handles positive magnitudes only */
-		periodic->magnitude = -periodic->magnitude;
+		magnitude = -magnitude;
 
 		/* to give the expected result 180 deg is added to the phase */
 		periodic->phase = (periodic->phase + (0x10000 / 2)) % 0x10000;
 	}
+	periodic->magnitude = min_t(s32, magnitude, S16_MAX);
 
 	/* the interval [0; 32677[ is used by the wheel for the [0; 360[ degree phase shift */
 	periodic->phase = periodic->phase * 32677 / 0x10000;
@@ -443,13 +448,16 @@ static void t300rs_calculate_ramp_parameters(uint16_t *out_slope,
 {
 	struct ff_ramp_effect *ramp = &effect->u.ramp;
 
-	int16_t start_level, end_level;
+	s32 start_level, end_level;
 
-	start_level = (ramp->start_level * fixp_sin16(effect->direction * 360 / 0x10000)) / 0x7fff;
-	end_level = (ramp->end_level * fixp_sin16(effect->direction * 360 / 0x10000)) / 0x7fff;
+	start_level = t300rs_scale_direction(ramp->start_level,
+					     effect->direction);
+	end_level = t300rs_scale_direction(ramp->end_level,
+					   effect->direction);
 
 	*out_slope = abs(start_level - end_level) / 2;
-	*out_center = (start_level + end_level) / 2;
+	*out_center = clamp_t(s32, (start_level + end_level) / 2,
+			      S16_MIN, S16_MAX);
 
 	*out_invert = (start_level < end_level) ? 0x04 : 0x05;
 }


### PR DESCRIPTION
## Summary

This series contains four independent correctness changes in force feedback and wheel input handling:

- restrict the configured driver gain to its documented unsigned 16-bit range
- avoid signed integer overflow when combining application and driver gain
- preserve the full signed effect range during direction scaling
- remove generic HID fuzz and flat filtering from wheel and pedal axes

The commits are intentionally kept separate so each change remains bisectable and can be reviewed or reverted independently.

No gain or rotation-range defaults are changed.

## Gain configuration and scaling

The configured driver gain is documented as an unsigned 16-bit value, but was stored and parsed as `int`. Values outside `0..65535` were accepted and silently clamped later.

The configured gain is now stored as `u16`. Module-parameter and sysfs values outside the documented range are rejected as invalid user input.

Both `FF_GAIN` and the driver gain use the full unsigned 16-bit range. Their product can exceed `INT_MAX`, so the existing signed multiplication invokes undefined behaviour for common configurations such as 75 percent application gain combined with 75 percent driver gain.

Gain multiplication now uses a `u32` intermediate, which can hold the product of two full-range 16-bit values. The initial and sysfs paths pass the already validated gain directly instead of using redundant multiply-divide expressions which could overflow before cancelling out.

## Signed effect scaling

The driver uses a symmetric fixed-point sine range of `-32767..32767`. Scaling the valid input value `-32768` by `-32767` therefore produces `32768`.

The old code stored that result in `s16` before completing the effect conversion, wrapping it to `-32768`. At full scale this could reverse the force direction instead of producing the expected positive force.

Direction-scaled values are now kept in `s32` until the destination range is known. Periodic magnitudes are made positive in the wider type and clamped to `S16_MAX`, preventing both the endpoint wrap and the subsequent invalid headroom calculation.

Constant and ramp effects retain their wider intermediates until their final conversion as well.

## Input filtering

The generic HID input setup derives fuzz and flat values from the logical axis range. On the tested T300 this produces:

```text
ABS_X: fuzz=255 flat=4095
pedals: fuzz=3 flat=63
```

The steering values suppress and smooth small corrections before an application receives them. This is particularly noticeable when changing steering direction.

flat represents a centered deadzone, which is also unsuitable for pedals whose rest position is an endpoint. Pedal fuzz can suppress small changes near an endpoint, causing the reported value to remain slightly short of the hardware endpoint.

The input setup now sets fuzz=0 and flat=0 for every available wheel and pedal axis on devices handled by hid-tmff2. Missing axes are skipped through the input device's absbit mask.

This follows the existing hid-universal-pidff precedent of overriding generic HID filtering for high-resolution racing devices.

## Related issues

- Addresses the underlying driver behaviour reported in #122. The reporter confirmed that setting both fuzz and flat to zero eliminates the small deadzone when changing steering direction.
- Likely addresses the force-direction wrap described in #34. That issue reports that reaching the positive force limit can suddenly jerk the wheel in the opposite direction, and its game-side workaround clamps the force just below that endpoint. This matches the signed 32768 to -32768 wrap fixed here, but still needs runtime confirmation.
- May address the kernel-generated portion of the deadzone reports in #42. That issue also contains joydev-, Wine- and runtime-specific cases, so this series does not claim to resolve every symptom discussed there.

## Testing

Completed on a T300RS GT:

- make and make W=1 against Linux 6.18.38
- git diff --check
- numerical validation across the complete signed effect input range
- loaded and tested the module built from this exact branch
- verified fuzz=0 and flat=0 on the steering and pedal axes
- regression-tested steering, pedals and Force Feedback in ETS2 under Proton
- exercised Constant, Ramp, Periodic, Spring, Damper and Friction effects
- exercised 100 percent driver master gain during normal gameplay

Damper and Friction effects were accepted without an observed error, although their individual contribution was subjectively subtle. Damper appeared to reduce wheel run-on, consistent with velocity-dependent damping.

Still pending before marking this PR ready:

- regression-test Forza Horizon 5 with the module built from this exact branch

Deferred hardware validation:

- related Thrustmaster wheel models are not locally available and will require testing by the maintainer or community
- additional master-gain values may be tested, but the scaling arithmetic has already been validated numerically over its full input range