### PR TITLE
preserve sub-degree force direction precision

### DIFF
--- a/src/tmt300rs/hid-tmt300rs.c
+++ b/src/tmt300rs/hid-tmt300rs.c
@@ -346,8 +346,8 @@ static uint16_t t300rs_calculate_length(uint16_t length)
 
 static s32 t300rs_scale_direction(s16 level, u16 direction)
 {
-	return DIV_ROUND_CLOSEST((s32)level *
-		fixp_sin16(direction * 360 / 0x10000), 0x7fff);
+	return DIV_S64_ROUND_CLOSEST((s64)level *
+		fixp_sin32_rad(direction, 0x10000), 0x7fffffff);
 }
 
 static int16_t t300rs_calculate_constant_level(int16_t level, uint16_t direction)


### PR DESCRIPTION
## Summary

Preserve the full sub-degree resolution of Linux force-feedback effect directions when projecting them onto the T300's single force axis.

## Motivation

The Linux force-feedback API encodes effect directions as a 16-bit turn. The previous T300 implementation first converted this value to an integer degree:

```c
fixp_sin16(direction * 360 / 0x10000)
```

This reduced 65536 possible directions to only 360 sine samples. The resulting one-degree staircase produces large quantization errors near the cardinal directions, which is particularly noticeable for weak steering-wheel effects.

## Changes

Use the kernel's full-resolution radial sine helper:

```c
fixp_sin32_rad(direction, 0x10000)
```

The calculation uses widened intermediate arithmetic and signed nearest-integer rounding before converting to the T300 protocol value.

This preserves the existing force sign, gain, range and T300 protocol mapping. No device defaults are changed.

## Simulation

The `ffb.ods` data from PR #105 was parsed independently directly from the embedded xml. The old and new direction projections were simulated over all 65536 Linux direction values at full force (`level = 32767`), using the actual kernel sine table and interpolation.

Absolute error against the mathematical sine:

| Projection | Mean | P50 | P90 | P95 | P99 | Maximum |
|------------|-----:|----:|----:|----:|----:|--------:|
| Old whole-degree projection | 182.02 | 147.66 | 407.69 | 466.27 | 534.88 | 572.27 |
| New radial projection | 1.18 | 1.03 | 2.41 | 2.81 | 3.41 | 4.33 |

The old projection therefore has a mean error of approximately 0.56% of full scale and a P99 error of approximately 1.63%. The new projection reduces this to approximately 0.0036% mean error and 0.0104% at P99.

P50/P90/P95/P99 are included because the old error is concentrated near the cardinal directions. A mean value alone hides how often a practically significant error occurs.

## Relation to PR #105

The PR #105 magnitude and periodic-phase protocol mappings are intentionally left unchanged. The direction projection and periodic phase encoding are independent calculations.

Nearest-integer rounding of the existing phase mapping changes its endpoint from `[0,32676]` to `[0,32677]`. A future raw USB comparison should verify whether the protocol requires a strict half-open `[0,32677)` interval before adding any endpoint clamp.

Likewise, the Windows ConstantForce range observed in #105 (`[-16385,16381]`) is not reproduced solely by this direction change. No additional model-specific endpoint adjustment is included here.

## Testing

- Simulated all 65536 direction values against the kernel sine table.
- Compared old whole-degree and new radial projections using P50/P90/P95/P99 error statistics.
- Tested the resulting driver behavior subjectively with weak ETS2 effects; small engine and road-surface forces became noticeably finer and less asymmetric.
